### PR TITLE
Fix K9－ØØ号 ルプス

### DIFF
--- a/c91025875.lua
+++ b/c91025875.lua
@@ -81,6 +81,7 @@ function s.xyzop(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsControler(1-tp) or not c:IsRelateToEffect(e) or c:IsFacedown() then return end
 	local mg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
 	local exg=Duel.GetMatchingGroup(s.exgfilter,tp,LOCATION_EXTRA,0,nil,mg,c)
+	if #exg<1 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sc=exg:Select(tp,1,1,nil):GetFirst()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)


### PR DESCRIPTION
Related Card:[K9－ØØ号 ルプス / K9-ØØ号 野狼](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21379&request_locale=ja)
About effect②
Bug: When there is not enough metrial for XYZSummon after activating this effect②, the function cannot run or end correctly.
Fix:   Add necessary function_exit_method.